### PR TITLE
tweaks: Minor tweaks to LTS transaction id

### DIFF
--- a/LTS.md
+++ b/LTS.md
@@ -97,7 +97,13 @@ const transaction = unsignedTransaction.compileNotarized(signature);
 (await transaction.staticallyValidate(NetworkId.Simulator)).throwIfInvalid();
 
 const notarizedTransactionHex = transaction.toHex();
+
+// The transaction intent hash is also known as the transaction id - and is used to
+// query APIs or the dashboard for transaction status.
 const transactionIntentHashHex = transaction.intentHashHex();
+// The payload hash - used to disambiguate multiple payloads for the same intent - in the unlikely
+// situation where a notary submits multiple distinct payloads for the same intent.
+const notarizedPayloadHashHex = transaction.notarizedPayloadHashHex();
 
 // You can then use these to interact with the Core API or Gateway API, eg with the Core API:
 // * Submit the `notarizedTransactionHex` to `/core/lts/transaction/submit`

--- a/LTS.md
+++ b/LTS.md
@@ -96,6 +96,7 @@ const transaction = unsignedTransaction.compileNotarized(signature);
 // Will throw if eg the signature is incorrect
 (await transaction.staticallyValidate(NetworkId.Simulator)).throwIfInvalid();
 
+// The notarized payload bytes in hex - for submitting to the network.
 const notarizedTransactionHex = transaction.toHex();
 
 // The transaction intent hash is also known as the transaction id - and is used to

--- a/LTS.md
+++ b/LTS.md
@@ -97,7 +97,7 @@ const transaction = unsignedTransaction.compileNotarized(signature);
 (await transaction.staticallyValidate(NetworkId.Simulator)).throwIfInvalid();
 
 const notarizedTransactionHex = transaction.toHex();
-const transactionIntentHashHex = transaction.transactionIdHex();
+const transactionIntentHashHex = transaction.intentHashHex();
 
 // You can then use these to interact with the Core API or Gateway API, eg with the Core API:
 // * Submit the `notarizedTransactionHex` to `/core/lts/transaction/submit`

--- a/src/builders/simple_transaction_builder.ts
+++ b/src/builders/simple_transaction_builder.ts
@@ -173,19 +173,16 @@ export class SimpleTransactionBuilder {
    */
   public compileIntent(): CompiledSignedTransactionIntent {
     const transitioned = this.transition();
-    const { intentHash: intentHash } = transitioned.compileIntent();
+    const { intentHash } = transitioned.compileIntent();
 
-    const {
-      compiledSignedIntent: compiledSignedTransactionIntent,
-      signedIntent: signedTransactionIntent,
-      signedIntentHash: signedIntentHash,
-    } = transitioned.compileSignedIntent();
+    const { compiledSignedIntent, signedIntent, signedIntentHash } =
+      transitioned.compileSignedIntent();
 
     return new CompiledSignedTransactionIntent(
       this.retWrapper,
       intentHash,
-      signedTransactionIntent,
-      compiledSignedTransactionIntent,
+      signedIntent,
+      compiledSignedIntent,
       signedIntentHash
     );
   }

--- a/src/builders/simple_transaction_builder.ts
+++ b/src/builders/simple_transaction_builder.ts
@@ -394,10 +394,12 @@ export class CompiledSignedTransactionIntent {
       CompileNotarizedTransactionResponse
     );
     let compiledNotarizedTransaction = response.compiledIntent;
+    let notarizedPayloadHash = hash(compiledNotarizedTransaction);
 
     return new CompiledNotarizedTransaction(
       this.retWrapper,
       compiledNotarizedTransaction,
+      notarizedPayloadHash,
       this.intentHash
     );
   }
@@ -414,15 +416,18 @@ export class CompiledNotarizedTransaction {
   private readonly retWrapper: RadixEngineToolkitWasmWrapper;
   readonly compiled: Uint8Array;
   readonly intentHash: Uint8Array;
+  readonly notarizedPayloadHash: Uint8Array;
 
   constructor(
     retWrapper: RadixEngineToolkitWasmWrapper,
     compiled: Uint8Array,
-    transactionId: Uint8Array
+    notarizedPayloadHash: Uint8Array,
+    intentHash: Uint8Array
   ) {
     this.retWrapper = retWrapper;
     this.compiled = compiled;
-    this.intentHash = transactionId;
+    this.notarizedPayloadHash = notarizedPayloadHash;
+    this.intentHash = intentHash;
   }
 
   /**
@@ -445,6 +450,13 @@ export class CompiledNotarizedTransaction {
    */
   intentHashHex(): string {
     return Convert.Uint8Array.toHexString(this.intentHash);
+  }
+
+  /**
+   * @returns The (notarized) payload hash, encoded into hex.
+   */
+  notarizedPayloadHashHex(): string {
+    return Convert.Uint8Array.toHexString(this.notarizedPayloadHash);
   }
 
   staticallyValidate(networkId: number): Promise<TransactionValidity> {

--- a/src/builders/transaction_builder.ts
+++ b/src/builders/transaction_builder.ts
@@ -112,27 +112,26 @@ export class TransactionBuilderIntentSignaturesStep {
   }
 
   public sign(source: SignatureSource): TransactionBuilderIntentSignaturesStep {
-    const { hashToSign } = this.buildTransactionIntent();
+    const { intentHash } = this.compileIntent();
 
-    this.intentSignatures.push(resolveSignature(source, hashToSign));
+    this.intentSignatures.push(resolveSignature(source, intentHash));
 
     return this;
   }
 
   public notarize(source: NotarySignatureSource): NotarizedTransaction {
-    let { signedTransactionIntent, hashToNotarize } =
-      this.buildSignedTransactionIntent();
+    const { signedIntent, signedIntentHash } = this.compileSignedIntent();
 
     return new NotarizedTransaction(
-      signedTransactionIntent,
-      resolveNotarySignature(source, hashToNotarize)
+      signedIntent,
+      resolveNotarySignature(source, signedIntentHash)
     );
   }
 
-  public buildTransactionIntent(): {
-    compiledTransactionIntent: Uint8Array;
-    transactionIntent: TransactionIntent;
-    hashToSign: Uint8Array;
+  public compileIntent(): {
+    compiledIntent: Uint8Array;
+    intent: TransactionIntent;
+    intentHash: Uint8Array;
   } {
     let request = this.intent;
     let response = this.retWrapper.invoke(
@@ -140,20 +139,20 @@ export class TransactionBuilderIntentSignaturesStep {
       this.retWrapper.exports.compile_transaction_intent,
       CompileTransactionIntentResponse
     );
-    let compiledTransactionIntent = response.compiledIntent;
+    let compiledIntent = response.compiledIntent;
 
-    let transactionIntentHash = hash(compiledTransactionIntent);
+    let intentHash = hash(compiledIntent);
     return {
-      compiledTransactionIntent,
-      transactionIntent: this.intent,
-      hashToSign: transactionIntentHash,
+      compiledIntent,
+      intent: this.intent,
+      intentHash,
     };
   }
 
-  public buildSignedTransactionIntent(): {
-    compiledSignedTransactionIntent: Uint8Array;
-    signedTransactionIntent: SignedTransactionIntent;
-    hashToNotarize: Uint8Array;
+  public compileSignedIntent(): {
+    compiledSignedIntent: Uint8Array;
+    signedIntent: SignedTransactionIntent;
+    signedIntentHash: Uint8Array;
   } {
     let signedIntent = new SignedTransactionIntent(
       this.intent,
@@ -164,13 +163,13 @@ export class TransactionBuilderIntentSignaturesStep {
       this.retWrapper.exports.compile_signed_transaction_intent,
       CompileSignedTransactionIntentResponse
     );
-    let compiledSignedTransactionIntent = response.compiledIntent;
+    let compiledSignedIntent = response.compiledIntent;
 
-    let signedTransactionIntentHash = hash(compiledSignedTransactionIntent);
+    let signedIntentHash = hash(compiledSignedIntent);
     return {
-      compiledSignedTransactionIntent,
-      signedTransactionIntent: signedIntent,
-      hashToNotarize: signedTransactionIntentHash,
+      compiledSignedIntent: compiledSignedIntent,
+      signedIntent,
+      signedIntentHash,
     };
   }
 }

--- a/src/models/transaction/notarized_intent.ts
+++ b/src/models/transaction/notarized_intent.ts
@@ -81,7 +81,9 @@ export class NotarizedTransaction {
     return this.compile().then(hash);
   }
 
-  async staticallyValidate(validationConfig: ValidationConfig): Promise<TransactionValidity> {
+  async staticallyValidate(
+    validationConfig: ValidationConfig
+  ): Promise<TransactionValidity> {
     return RadixEngineToolkit.staticallyValidateTransaction(
       this,
       validationConfig

--- a/src/models/transaction/notarized_intent.ts
+++ b/src/models/transaction/notarized_intent.ts
@@ -70,6 +70,10 @@ export class NotarizedTransaction {
   }
 
   async transactionId(): Promise<Uint8Array> {
+    return this.intentHash();
+  }
+
+  async intentHash(): Promise<Uint8Array> {
     return this.signedIntent.intent.transactionId();
   }
 
@@ -77,7 +81,7 @@ export class NotarizedTransaction {
     return this.signedIntent.signedIntentHash();
   }
 
-  async notarizedIntentHash(): Promise<Uint8Array> {
+  async notarizedPayloadHash(): Promise<Uint8Array> {
     return this.compile().then(hash);
   }
 


### PR DESCRIPTION
Just some minor tweaks that I thought of last night after shutting off the computer - to further align with the Core API docs and nomenclature.